### PR TITLE
feat: add and populate format section/field

### DIFF
--- a/site/plugins/2025-blueprint/blueprints/pages/2025.php
+++ b/site/plugins/2025-blueprint/blueprints/pages/2025.php
@@ -221,7 +221,6 @@ return [
                                         'de' => 'Format',
                                     ],
                                     'max' => 1,
-                                    // 'format_options' => $format_options,
                                     'options' => [
                                       'exhibition' => [
                                         'en' => 'exhibition',


### PR DESCRIPTION
@aofn Not a blocker, just for documentations’ sake: I don’t quite like de: „Weitere“ / en: „other“ and reached out to the organisation team for their input on how to change that label. Also, I wonder if we should capitalise the English labels, but I think I tend not to.