### PR TITLE
draft: expose contexts, formats, locations via api

### DIFF
--- a/site/plugins/api/index.php
+++ b/site/plugins/api/index.php
@@ -21,6 +21,26 @@ Kirby::plugin('medienhaus/api', [
                     return asset('assets/2025/locations.json')->read();
                 },
             ],
+            /*
+            [
+                'pattern' => '2026/contexts',
+                'action' => function () {
+                    return asset('assets/2026/contexts.json')->read();
+                },
+            ],
+            [
+                'pattern' => '2026/formats',
+                'action' => function () {
+                    return asset('assets/2026/formats.json')->read();
+                },
+            ],
+            [
+                'pattern' => '2026/locations',
+                'action' => function () {
+                    return asset('assets/2026/locations.json')->read();
+                },
+            ],
+             */
         ],
     ],
 ]);


### PR DESCRIPTION
@aofn Would we want to expose all `.json` files via the API?

We could also change the `assets` folder structure; not sure if we need/want the `json/` subdirectory?

```
assets/
  2025/
    contexts.json
    formats.json
    locations.json
  2026/
    contexts.json
    formats.json
    locations.json
 ```