### PR TITLE
feat: add title_image field to short description tab

### DIFF
--- a/site/plugins/2025-blueprint/blueprints/pages/2025.php
+++ b/site/plugins/2025-blueprint/blueprints/pages/2025.php
@@ -744,11 +744,56 @@ return [
                                         'de' => 'Kurzbeschreibung',
                                     ],
                                     'buttons' => false,
+                                    'help' => [
+                                        'en' => 'The short description might be shown in the content overview next to some more metadata.',
+                                        'de' => 'Die Kurzbeschreibung wäre in der Inhaltsübersicht zu sehen, neben weiteren Metadaten.',
+                                    ],
                                     'icon' => 'title',
                                     'maxlength' => 500,
                                     'required' => true,
                                     'size' => 'small',
                                     'uploads' => false,
+                                ],
+
+                                # docs: https://getkirby.com/docs/reference/panel/fields/info
+                                #
+                                'intro_field_single_language' => [
+                                    'type' => 'info',
+                                    'label' => false,
+                                    'icon' => 'translate',
+                                    'text' => [
+                                        'en' => 'The <strong>Title Image</strong> field can only be uploaded for the default language, i.e. <strong>DE</strong> in the dropdown menu above, next to the page title.',
+                                        'de' => 'Das <strong>Titelbild</strong> kann nur für die Standard-Sprache hochgeladen werden, d.h. <strong>DE</strong> im Dropdown-Menü neben/unter dem Seiten-Titel.',
+                                    ],
+                                    'theme' => 'notice',
+                                ],
+
+                                # docs: https://getkirby.com/docs/reference/panel/fields/blocks
+                                #
+                                'intro_field_title_image' => [
+                                    'type' => 'blocks',
+                                    'label' => [
+                                        'en' => 'Title Image',
+                                        'de' => 'Titelbild',
+                                    ],
+                                    'default' => [
+                                        [
+                                            'type' => 'image',
+                                        ],
+                                    ],
+                                    'empty' => [
+                                        'en' => 'Please upload a title image …',
+                                        'de' => 'Bitte lade ein Titelbild hoch …',
+                                    ],
+                                    'fieldsets' => [
+                                        'image',
+                                    ],
+                                    'help' => [
+                                        'en' => 'The title image might be shown in the content overview next to some more metadata.',
+                                        'de' => 'Das Titelbild wäre in der Inhaltsübersicht zu sehen, neben weiteren Metadaten.',
+                                    ],
+                                    'max' => '1',
+                                    'translate' => false,
                                 ],
                             ],
                         ],

--- a/site/plugins/2026-blueprint/blueprints/pages/2026.php
+++ b/site/plugins/2026-blueprint/blueprints/pages/2026.php
@@ -15,7 +15,7 @@ function sanitizeId(string $id): string
 // flatten the nested structure
 //
 foreach ($context_data['faculties'] as $faculty) {
-    $faculty_id = Str::slug(Str::camel($faculty['name']));
+    $faculty_id = $faculty['id'];
     $faculty_text = $faculty['name'];
     $faculty_info = $faculty['name'];
 
@@ -30,7 +30,7 @@ foreach ($context_data['faculties'] as $faculty) {
     }
 
     foreach ($faculty['institutes'] as $institute) {
-        $institute_id = Str::slug(Str::camel($institute['name']));
+        $institute_id = $institute['id'];
         $institute_text = $institute['name'];
         $institute_info = $institute['name'] . ' - ' . $faculty['name'];
 
@@ -45,7 +45,7 @@ foreach ($context_data['faculties'] as $faculty) {
         }
 
         foreach ($institute['courses'] as $course) {
-            $course_id = Str::slug(Str::camel($course['name']));
+            $course_id = $course['id'];
             $course_text = $course['name'];
             $course_info = $course['name'] . ' - ' . $institute['name'] . ' - ' . $faculty['name'];
 
@@ -60,7 +60,7 @@ foreach ($context_data['faculties'] as $faculty) {
             }
 
             foreach ($course['classes'] as $class) {
-                $id = Str::slug(Str::camel($class['name']));
+                $id = $class['id'];
                 $text = $class['name'];
                 $info = $class['name'] . ' - ' . $course['name'] . ' - ' . $institute['name'] . ' - ' . $faculty['name'];
 
@@ -744,11 +744,56 @@ return [
                                         'de' => 'Kurzbeschreibung',
                                     ],
                                     'buttons' => false,
+                                    'help' => [
+                                        'en' => 'The short description might be shown in the content overview next to some more metadata.',
+                                        'de' => 'Die Kurzbeschreibung wäre in der Inhaltsübersicht zu sehen, neben weiteren Metadaten.',
+                                    ],
                                     'icon' => 'title',
                                     'maxlength' => 500,
                                     'required' => true,
                                     'size' => 'small',
                                     'uploads' => false,
+                                ],
+
+                                # docs: https://getkirby.com/docs/reference/panel/fields/info
+                                #
+                                'intro_field_single_language' => [
+                                    'type' => 'info',
+                                    'label' => false,
+                                    'icon' => 'translate',
+                                    'text' => [
+                                        'en' => 'The <strong>Title Image</strong> field can only be uploaded for the default language, i.e. <strong>DE</strong> in the dropdown menu above, next to the page title.',
+                                        'de' => 'Das <strong>Titelbild</strong> kann nur für die Standard-Sprache hochgeladen werden, d.h. <strong>DE</strong> im Dropdown-Menü neben/unter dem Seiten-Titel.',
+                                    ],
+                                    'theme' => 'notice',
+                                ],
+
+                                # docs: https://getkirby.com/docs/reference/panel/fields/blocks
+                                #
+                                'intro_field_title_image' => [
+                                    'type' => 'blocks',
+                                    'label' => [
+                                        'en' => 'Title Image',
+                                        'de' => 'Titelbild',
+                                    ],
+                                    'default' => [
+                                        [
+                                            'type' => 'image',
+                                        ],
+                                    ],
+                                    'empty' => [
+                                        'en' => 'Please upload a title image …',
+                                        'de' => 'Bitte lade ein Titelbild hoch …',
+                                    ],
+                                    'fieldsets' => [
+                                        'image',
+                                    ],
+                                    'help' => [
+                                        'en' => 'The title image might be shown in the content overview next to some more metadata.',
+                                        'de' => 'Das Titelbild wäre in der Inhaltsübersicht zu sehen, neben weiteren Metadaten.',
+                                    ],
+                                    'max' => '1',
+                                    'translate' => false,
                                 ],
                             ],
                         ],


### PR DESCRIPTION
Adding a new field to the description tab, which allows users to upload one specific title image for their content, which might be shown in the content overview section on the website.

@benhe0 Your soon-to-be-uploaded mock data script would need to be adapted to these changes.