### PR TITLE
chore: prevent modification during/after rundgang

### DIFF
--- a/site/plugins/2025-blueprint/blueprints/pages/2025.php
+++ b/site/plugins/2025-blueprint/blueprints/pages/2025.php
@@ -1233,7 +1233,6 @@ return [
     #
     # NOTE: uncomment complete `options` block to prevent editing/modification
     # of pages after publication deadline and/or after the Rundgang is over !!
-    /*
     'options' => [
         //'access' => [
         //  "*" => false,
@@ -1292,5 +1291,4 @@ return [
             "admin" => true,
         ],
     ],
-    */
 ];


### PR DESCRIPTION
@aofn This should be all necessary changes for preventing any modifications during/after Rundgang.

You’d need to merge this on the day the Rundgang start; you should receive two alerts via our calendar.

Please feel free to test this locally, but it seems to work for me on my machine™ …