### PR TITLE
feat: no appointments on specific days

### DIFF
--- a/site/plugins/2025-blueprint/blueprints/pages/2025.php
+++ b/site/plugins/2025-blueprint/blueprints/pages/2025.php
@@ -729,6 +729,10 @@ return [
                                             'en' => 'Specific Hours',
                                             'de' => 'Bestimmte Uhrzeiten',
                                         ],
+                                        'none' => [
+                                            'en' => 'No Appointments',
+                                            'de' => 'Keine Termine',
+                                        ],
                                     ],
                                     'default' => 'allday',
                                     'required' => true,
@@ -848,6 +852,10 @@ return [
                                             'en' => 'Specific Hours',
                                             'de' => 'Bestimmte Uhrzeiten',
                                         ],
+                                        'none' => [
+                                            'en' => 'No Appointments',
+                                            'de' => 'Keine Termine',
+                                        ],
                                     ],
                                     'default' => 'allday',
                                     'required' => true,
@@ -966,6 +974,10 @@ return [
                                         'datetime' => [
                                             'en' => 'Specific Hours',
                                             'de' => 'Bestimmte Uhrzeiten',
+                                        ],
+                                        'none' => [
+                                            'en' => 'No Appointments',
+                                            'de' => 'Keine Termine',
                                         ],
                                     ],
                                     'default' => 'allday',


### PR DESCRIPTION
This adds an option for “no appointments” on specific days.

@benhe0 @p6gb @orlando-helfer Do you need to implement any changes to make this work, or will this simply result in no times being shown on the website?