### PR TITLE
feat: add toggle for authorship visibility

### DIFF
--- a/site/plugins/2025-blueprint/blueprints/pages/2025.php
+++ b/site/plugins/2025-blueprint/blueprints/pages/2025.php
@@ -242,6 +242,27 @@ return [
                                     ],
                                     'theme' => 'passive',
                                 ],
+
+                                # docs: https://getkirby.com/docs/reference/panel/fields/toggle
+                                #
+                                'authorship_visibility' => [
+                                    'type' => 'toggle',
+                                    'label' => [
+                                        'en' => 'Authorship',
+                                        'de' => 'Autor:innenschaft',
+                                    ],
+                                    'help' => [
+                                        'en' => 'This option let’s you hide or show the authorship and co-author(s) on the website.',
+                                        'de' => 'Mit dieser Option kann die Autor:innenshaft auf der Website ein- oder ausgeblendet werden.',
+                                    ],
+                                    'default' => false,
+                                    'icon' => 'tag',
+                                    'text' => [
+                                        'en' => 'Hide <em>authorship</em> and <em>co-authors</em>?',
+                                        'de' => '<em>Autor:innenschaft</em> und <em>Co-Autor:innen</em> ausblenden?',
+                                    ],
+                                    'translate' => false,
+                                ],
                             ],
                         ],
 


### PR DESCRIPTION
This adds a toggle for “hide authorship” on website.

@benhe0 @p6gb @orlando-helfer As written via mail, this toggle would dictate the conditional display of the author’s display name and the optional co-author display names. Please let us know once implemented.

<img width="1158" alt="Screenshot 2025-07-07 at 11 28 15" src="https://github.com/user-attachments/assets/b07e6fac-42c1-4a1a-846e-045b9a055515" />
