### PR TITLE
fix: use `id` key for location ids from `location.json`

### DIFF
--- a/site/plugins/2025-blueprint/blueprints/pages/2025.php
+++ b/site/plugins/2025-blueprint/blueprints/pages/2025.php
@@ -528,7 +528,7 @@ return [
                                         'url' => 'assets/2025/locations.json',
                                         'query' => 'sortBy("name", "asc")',
                                         'text' => '{{ item.name }}',
-                                        'value' => '{{ item.name.slug }}',
+                                        'value' => '{{ item.id }}',
                                     ],
                                     #'required' => true,
                                     'translate' => false,


### PR DESCRIPTION
Use correct id from `location.json` for location ids instead of slug.