### PR TITLE
Remove unused sanitizeId functions

### DIFF
--- a/site/plugins/2025-blueprint/blueprints/pages/2025.php
+++ b/site/plugins/2025-blueprint/blueprints/pages/2025.php
@@ -6,13 +6,6 @@ $context_json = asset('assets/2025/contexts.json')->read();
 $context_data = json_decode($context_json, true);
 $context_options = [];
 
-// sanitize string by removing all space characters
-//
-function sanitizeId(string $id): string
-{
-    return str_replace(' ', '', $id);
-}
-
 // flatten the nested structure
 //
 foreach ($context_data['faculties'] as $faculty) {

--- a/site/plugins/2026-blueprint/blueprints/pages/2026.php
+++ b/site/plugins/2026-blueprint/blueprints/pages/2026.php
@@ -6,13 +6,6 @@ $context_json = asset('assets/2026/contexts.json')->read();
 $context_data = json_decode($context_json, true);
 $context_options = [];
 
-// sanitize string by removing all space characters
-//
-function sanitizeId(string $id): string
-{
-    return str_replace(' ', '', $id);
-}
-
 // flatten the nested structure
 //
 foreach ($context_data['faculties'] as $faculty) {


### PR DESCRIPTION
Not only was this function never being used, it also errored having defined this twice:

```
2026/07/06 18:29:41 [error] 469#469: *53 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Cannot redeclare sanitizeId() (previously declared in /var/www/kirby/site/plugins/2025-blueprint/blueprints/pages/2025.php:11) in /var/www/kirby/site/plugins/2026-blueprint/blueprints/pages/2026.php on line 11; PHP message: Whoops\Exception\ErrorException: Cannot redeclare sanitizeId() (previously declared in /var/www/kirby/site/plugins/2025-blueprint/blueprints/pages/2025.php:11) in /var/www/kirby/site/plugins/2026-blueprint/blueprints/pages/2026.php:11
Stack trace:
#0 /var/www/kirby/kirby/vendor/filp/whoops/src/Whoops/Run.php(520): Whoops\Run->handleError()
#1 [internal function]: Whoops\Run->handleShutdown()
#2 {main}" while reading response header from upstream, client: 194.95.203.223, server: rundgang-cms.udk-berlin.de, request: "GET /api/site/sections/content_2025? HTTP/1.1", upstream: "fastcgi://unix:/run/php/php-fpm.sock:", host: "rundgang-cms.udk-berlin.de", referrer: "https://rundgang-cms.udk-berlin.de/panel/site"
```